### PR TITLE
Use dashboard obj as dict.

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -836,25 +836,27 @@ class Dashboard(object):
 
     def to_json_data(self):
         return {
-            '__inputs': self.inputs,
-            'annotations': self.annotations,
-            'editable': self.editable,
-            'gnetId': self.gnetId,
-            'hideControls': self.hideControls,
-            'id': self.id,
-            'links': self.links,
-            'refresh': self.refresh,
-            'rows': self.rows,
-            'schemaVersion': self.schemaVersion,
-            'sharedCrosshair': self.sharedCrosshair,
-            'style': self.style,
-            'tags': self.tags,
-            'templating': self.templating,
-            'title': self.title,
-            'time': self.time,
-            'timepicker': self.timePicker,
-            'timezone': self.timezone,
-            'version': self.version,
+            'dashboard': {
+                '__inputs': self.inputs,
+                'annotations': self.annotations,
+                'editable': self.editable,
+                'gnetId': self.gnetId,
+                'hideControls': self.hideControls,
+                'id': self.id,
+                'links': self.links,
+                'refresh': self.refresh,
+                'rows': self.rows,
+                'schemaVersion': self.schemaVersion,
+                'sharedCrosshair': self.sharedCrosshair,
+                'style': self.style,
+                'tags': self.tags,
+                'templating': self.templating,
+                'title': self.title,
+                'time': self.time,
+                'timepicker': self.timePicker,
+                'timezone': self.timezone,
+                'version': self.version,
+            }
         }
 
 


### PR DESCRIPTION
In order to use the grafana api (http) to load jsons, the json file must use dashboard as list.
the following patch make sure we follow the grafana api format.
otherwise the following command will fail with this:
```curl -H "Content-Type: application/json" -u admin:admin "https://grafanaserver/api/dashboards/db" -X POST -d "@f.json"```
[{"fieldNames":["Dashboard"],"classification":"RequiredError","message":"Required"}]root

@jml PTAL
/cc @jeremyeder